### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Unlock the power of AI-driven infrastructure analysis with [Steampipe](https://steampipe.io)! This Model Context Protocol server seamlessly connects AI assistants like Claude to your cloud infrastructure data, enabling natural language exploration and analysis of your entire cloud estate.
 
+<a href="https://glama.ai/mcp/servers/@turbot/steampipe-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@turbot/steampipe-mcp/badge" alt="steampipe-mcp MCP server" />
+</a>
+
 Steampipe MCP bridges AI assistants and your infrastructure data, allowing natural language:
 - Queries across AWS, Azure, GCP and 100+ cloud services
 - Security and compliance analysis


### PR DESCRIPTION
This PR adds a badge for the [steampipe-mcp](https://glama.ai/mcp/servers/@turbot/steampipe-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@turbot/steampipe-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@turbot/steampipe-mcp/badge" alt="steampipe-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.