### PR TITLE
Safe `bigint` values are now returned as `int` instead of `string` type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "@types/pg": "^8.11.2",
         "shx": "^0.3.4",
         "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { DatabaseService } from "./services/database.js";
+import { configureTypeParser } from "./services/database-config.js";
 import { setupTools, tools } from "./tools/index.js";
 import { setupPromptHandlers, promptCapabilities } from "./prompts/index.js";
 import { setupResourceHandlers, resourceCapabilities } from "./resources/index.js";
@@ -55,6 +56,9 @@ export async function startServer(port: number = 27123) {
   logger.info(`Starting server on port ${port}`);
 
   try {
+    // Configure global type parsers
+    configureTypeParser();
+
     // Get database service instance (but don't connect yet)
     const db = DatabaseService.getInstance();
 

--- a/src/services/database-config.ts
+++ b/src/services/database-config.ts
@@ -1,0 +1,20 @@
+import pkg from 'pg';
+const { types } = pkg;
+
+/**
+ * Configure global PostgreSQL type parsers
+ * This affects all database connections in the application
+ */
+export function configureTypeParser() {
+  // Configure type parser for bigint (OID: 20)
+  types.setTypeParser(20, function(val) {
+    if (val === null) return null;
+    const parsed = parseInt(val, 10);
+    // Only convert to number if within safe integer range
+    if (parsed <= Number.MAX_SAFE_INTEGER && parsed >= Number.MIN_SAFE_INTEGER) {
+      return parsed;
+    }
+    // For values outside safe range, return as string
+    return val;
+  });
+} 

--- a/src/tools/steampipe_query.ts
+++ b/src/tools/steampipe_query.ts
@@ -34,28 +34,8 @@ export const tool: Tool = {
 
     try {
       const rows = await db.executeQuery(args.sql);
-      
-      // Handle BigInt serialization by converting to Numbers or Strings
-      const processedRows = rows.map(row => {
-        const processedRow: Record<string, any> = {};
-        Object.entries(row).forEach(([key, value]) => {
-          if (typeof value === 'bigint') {
-            // Convert BigInt to a regular number if it fits within safe integer range
-            if (value <= Number.MAX_SAFE_INTEGER && value >= Number.MIN_SAFE_INTEGER) {
-              processedRow[key] = Number(value);
-            } else {
-              // Otherwise convert to string to avoid precision loss
-              processedRow[key] = value.toString();
-            }
-          } else {
-            processedRow[key] = value;
-          }
-        });
-        return processedRow;
-      });
-
       return {
-        content: [{ type: "text", text: JSON.stringify(processedRows) }],
+        content: [{ type: "text", text: JSON.stringify(rows) }],
         isError: false
       };
     } catch (error) {


### PR DESCRIPTION
**Note**: I'm not 100% sure on where the function should live, open to any suggestions.

<details><summary>Test Results</summary>

### Test Query
```sql
WITH test_values AS (
  SELECT 
    1234567890 as normal_int,
    9223372036854775807 as max_bigint,
    -9223372036854775808 as min_bigint,
    9007199254740991 as max_safe_integer,
    -9007199254740991 as min_safe_integer
)
SELECT * FROM test_values;
```

### Results
```json
{
  "normal_int": 1234567890,
  "max_bigint": "9223372036854775807",
  "min_bigint": "-9223372036854775808",
  "max_safe_integer": 9007199254740991,
  "min_safe_integer": -9007199254740991
}
```

### Analysis

The results demonstrate the type parser's behavior as configured in `database-config.ts`:

1. **Normal integers** (`1234567890`)
   - Returned as regular numbers since within safe integer range

2. **Max BigInt** (`9223372036854775807`)
   - Returned as string since exceeds `Number.MAX_SAFE_INTEGER`
   - Preserves full precision of 64-bit integer

3. **Min BigInt** (`-9223372036854775808`)
   - Returned as string since exceeds `Number.MIN_SAFE_INTEGER`
   - Preserves full precision of 64-bit integer

4. **Max Safe Integer** (`9007199254740991`)
   - Returned as number since equals `Number.MAX_SAFE_INTEGER`
   - Represents maximum precise integer in JavaScript

5. **Min Safe Integer** (`-9007199254740991`)
   - Returned as number since equals `Number.MIN_SAFE_INTEGER`
   - Represents minimum precise integer in JavaScript

The test confirms:
- Safe range values (-2^53+1 to 2^53-1) return as numbers
- Values outside safe range preserved as strings
- Precision maintained for large numbers
- Correct handling of both positive and negative values
</details>